### PR TITLE
bug fixes encountered while using CUTIE in MMEDS

### DIFF
--- a/cutie/output.py
+++ b/cutie/output.py
@@ -700,7 +700,7 @@ def diag_plots(samp_ids, var1_names, var2_names, samp_counter, var1_counter,
         name_mapping = {'samp_number': samp_ids,
                          'var_number': var1_names}
         file_mapping = {'samp_number': 'influential_samples',
-                         'var1_number': 'influential_variables',
+                         'var_number': 'influential_variables'}
     else:
         diag_stats = ['samp_number', 'var1_number', 'var2_number']
         stats_mapping = {'samp_number': samp_counter,
@@ -735,7 +735,7 @@ def diag_plots(samp_ids, var1_names, var2_names, samp_counter, var1_counter,
 
             counts_df = pd.DataFrame(
                 {stats: counts[:, 0], false_label: counts[:, i+1]})
-            sns.lmplot(stats, false_label, data=counts_df,
+            sns.lmplot(data=counts_df, x=stats, y=false_label,
                        fit_reg=False)
 
 

--- a/cutie/parse.py
+++ b/cutie/parse.py
@@ -38,7 +38,7 @@ def parse_input(ftype, fp, startcol, endcol, delimiter, skip):
     """
 
     # read in df and set index
-    df = pd.read_csv(fp, sep=delimiter, skiprows=skip, engine='python')
+    df = pd.read_csv(fp, sep=delimiter, skiprows=skip, engine='python', dtype='str')
     df = df.set_index(list(df)[0])
 
     # remove completely NA rows or vars

--- a/cutie/utils.py
+++ b/cutie/utils.py
@@ -234,9 +234,13 @@ def read_taxa(taxa, delim=';'):
     """
     parts = taxa.split(delim) # set as param with default
     while parts:
-        if not parts[-1].endswith('__'):
-            taxastr1 = parts[-2].split('__')[1]
-            taxastr2 = parts[-1].split('__')[1]
+        if not parts[-1].endswith('__') and len(parts) > 1:
+            if len(parts[-2].split('__')) > 1:
+                taxastr1 = parts[-2].split('__')[1]
+                taxastr2 = parts[-1].split('__')[1]
+            else:
+                taxastr1 = parts[-2]
+                taxastr2 = parts[-1]
             return taxastr1 + ' ' + taxastr2
         else:
             parts.pop()


### PR DESCRIPTION
Fixes the following bugs:
-Index out of bounds error when working with taxa that have only 1 or 2 components
-Incorrectly reading sample IDs as numbers when IDs are entirely numeric
-Missing close bracket, as stated in #127 

Closes #127